### PR TITLE
Preserving star imports in Organize Imports

### DIFF
--- a/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/codemanipulation/OrganizeImportsOperation.java
+++ b/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/codemanipulation/OrganizeImportsOperation.java
@@ -282,6 +282,12 @@ public class OrganizeImportsOperation implements IWorkspaceRunnable {
 			if (nFound == 0) {
 				// nothing found
 				return null;
+			} else if (fDoPreserveDemandImports && fOldDemandImports.contains(typeRefsFound.get(0).getTypeContainerName())) {
+				// The original code had a * import for this type. Preserve it!
+				TypeNameMatch typeRef= typeRefsFound.get(0);
+				String containerName= typeRef.getTypeContainerName();
+				fImpStructure.addImport(containerName);
+				return null;
 			} else if (nFound == 1) {
 				TypeNameMatch typeRef= typeRefsFound.get(0);
 				fImpStructure.addImport(typeRef.getFullyQualifiedName());


### PR DESCRIPTION
When Organize Imports is triggered, existing star imports are preserved. None are added, if they don't exist before.